### PR TITLE
Added quick and dirty BulkUpsert type

### DIFF
--- a/src/Database/V5/Bloodhound/Client.hs
+++ b/src/Database/V5/Bloodhound/Client.hs
@@ -884,9 +884,12 @@ encodeBulkOperation (BulkUpdate (IndexName indexName)
 
 encodeBulkOperation (BulkUpsert (IndexName indexName)
                 (MappingName mappingName)
-                (DocId docId) value (UpsertMetadata moreMeta)) = blob
-    where metadata = mkBulkStreamValueWithMeta moreMeta "update" indexName mappingName docId
-          doc = object ["doc" .= value]
+                (DocId docId)
+                value
+                (UpsertActionMetadata actionMeta)
+                (UpsertDocMetadata docMeta)) = blob
+    where metadata = mkBulkStreamValueWithMeta actionMeta "update" indexName mappingName docId
+          doc = object $ ["doc" .= value] <> docMeta
           blob = encode metadata <> "\n" <> encode doc
 
 -- | 'getDocument' is a straight-forward way to fetch a single document from

--- a/src/Database/V5/Bloodhound/Types.hs
+++ b/src/Database/V5/Bloodhound/Types.hs
@@ -161,6 +161,7 @@ module Database.V5.Bloodhound.Types
        , TemplatePattern(..)
        , MappingName(..)
        , DocId(..)
+       , UpsertMetadata(..)
        , CacheName(..)
        , CacheKey(..)
        , BulkOperation(..)
@@ -689,6 +690,8 @@ data MappingField =
 data Mapping = Mapping { typeName      :: TypeName
                        , mappingFields :: [MappingField] } deriving (Eq, Read, Show, Generic, Typeable)
 
+newtype UpsertMetadata = UpsertMetadata [Pair] deriving (Eq, Read, Show, Generic, Typeable)
+
 {-| 'BulkOperation' is a sum type for expressing the four kinds of bulk
     operation index, create, delete, and update. 'BulkIndex' behaves like an
     "upsert", 'BulkCreate' will fail if a document already exists at the DocId.
@@ -699,7 +702,9 @@ data BulkOperation =
     BulkIndex  IndexName MappingName DocId Value
   | BulkCreate IndexName MappingName DocId Value
   | BulkDelete IndexName MappingName DocId
-  | BulkUpdate IndexName MappingName DocId Value deriving (Eq, Read, Show, Generic, Typeable)
+  | BulkUpdate IndexName MappingName DocId Value
+  | BulkUpsert IndexName MappingName DocId Value UpsertMetadata
+  deriving (Eq, Read, Show, Generic, Typeable)
 
 {-| 'EsResult' describes the standard wrapper JSON document that you see in
     successful Elasticsearch lookups or lookups that couldn't find the document.

--- a/src/Database/V5/Bloodhound/Types.hs
+++ b/src/Database/V5/Bloodhound/Types.hs
@@ -161,7 +161,8 @@ module Database.V5.Bloodhound.Types
        , TemplatePattern(..)
        , MappingName(..)
        , DocId(..)
-       , UpsertMetadata(..)
+       , UpsertActionMetadata(..)
+       , UpsertDocMetadata(..)
        , CacheName(..)
        , CacheKey(..)
        , BulkOperation(..)
@@ -690,7 +691,8 @@ data MappingField =
 data Mapping = Mapping { typeName      :: TypeName
                        , mappingFields :: [MappingField] } deriving (Eq, Read, Show, Generic, Typeable)
 
-newtype UpsertMetadata = UpsertMetadata [Pair] deriving (Eq, Read, Show, Generic, Typeable)
+newtype UpsertActionMetadata = UpsertActionMetadata [Pair] deriving (Eq, Read, Show, Generic, Typeable)
+newtype UpsertDocMetadata    = UpsertDocMetadata [Pair] deriving (Eq, Read, Show, Generic, Typeable)
 
 {-| 'BulkOperation' is a sum type for expressing the four kinds of bulk
     operation index, create, delete, and update. 'BulkIndex' behaves like an
@@ -703,7 +705,7 @@ data BulkOperation =
   | BulkCreate IndexName MappingName DocId Value
   | BulkDelete IndexName MappingName DocId
   | BulkUpdate IndexName MappingName DocId Value
-  | BulkUpsert IndexName MappingName DocId Value UpsertMetadata
+  | BulkUpsert IndexName MappingName DocId Value UpsertActionMetadata UpsertDocMetadata
   deriving (Eq, Read, Show, Generic, Typeable)
 
 {-| 'EsResult' describes the standard wrapper JSON document that you see in


### PR DESCRIPTION
Added a BulkUpsert type to the other Bulk* types, so we can carry the
metadata we need through to the call. Currently just passes K-V pairs
straight through.

Also replaced infixed `mappened` with `<>`, and removed some trailing
spaces.