### PR TITLE
Add deleteByQuery

### DIFF
--- a/src/Database/V5/Bloodhound/Client.hs
+++ b/src/Database/V5/Bloodhound/Client.hs
@@ -52,6 +52,7 @@ module Database.V5.Bloodhound.Client
        , getDocument
        , documentExists
        , deleteDocument
+       , deleteByQuery
        -- ** Searching
        , searchAll
        , searchByIndex
@@ -862,6 +863,17 @@ deleteDocument :: MonadBH m => IndexName -> MappingName
 deleteDocument (IndexName indexName)
   (MappingName mappingName) (DocId docId) =
   delete =<< joinPath [indexName, mappingName, docId]
+
+-- | 'deleteByQuery' performs a deletion on every document that matches a query.
+--
+-- >>> let query = TermQuery (Term "user" "bitemyapp") Nothing
+-- >>> _ <- runBH' $ deleteDocument testIndex testMapping query
+deleteByQuery :: MonadBH m => IndexName -> MappingName -> Query -> m Reply
+deleteByQuery (IndexName indexName) (MappingName mappingName) query =
+  bindM2 post url (return body)
+  where
+    url = joinPath [indexName, mappingName, "_delete_by_query"]
+    body = Just (encode $ object [ "query" .= query ])
 
 -- | 'bulk' uses
 --    <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html Elasticsearch's bulk API>


### PR DESCRIPTION
Given:
```
$ curl -X GET "localhost:9200/test1/doubles/_search" -H 'Content-Type: application/json'
{"took":4,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":2,"max_score":1.0,"hits":[{"_index":"test1","_type":"doubles","_id":"2","_score":1.0,"_source":
{
  "name": "long",
  "double": 8.00
}},{"_index":"test1","_type":"doubles","_id":"1","_score":1.0,"_source":
{
  "name": "long",
  "double": 9223372036854775807.00
}}]}}
```

When:
```
λ: let query = QueryRangeQuery (mkRangeQuery (FieldName "double") (RangeDoubleGte (GreaterThanEq 10)))
λ: runBH' $ deleteByQuery testIndex testMapping query
Response {responseStatus = Status {statusCode = 200, statusMessage = "OK"}, responseVersion = HTTP/1.1, responseHeaders = [("content-type","application/json; charset=UTF-8"),("content-encoding","gzip"),("content-length","168")], responseBody = "{\"took\":17,\"timed_out\":false,\"total\":1,\"deleted\":1,\"batches\":1,\"version_conflicts\":0,\"noops\":0,\"retries\":{\"bulk\":0,\"search\":0},\"throttled_millis\":0,\"requests_per_second\":-1.0,\"throttled_until_millis\":0,\"failures\":[]}", responseCookieJar = CJ {expose = []}, responseClose' = ResponseClose}
```

Then:
```
$ curl -X GET "localhost:9200/test1/doubles/_search" -H 'Content-Type: application/json'
{"took":4,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":1,"max_score":1.0,"hits":[{"_index":"test1","_type":"doubles","_id":"2","_score":1.0,"_source":
{
  "name": "long",
  "double": 8.00
}}]}}
```