### PR TITLE
Add support for `count` endpoint

### DIFF
--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -67,6 +67,7 @@ module Database.Bloodhound.Client
        , advanceScroll
        , refreshIndex
        , mkSearch
+       , mkCount
        , mkAggregateSearch
        , mkHighlightSearch
        , mkSearchTemplate

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -1245,20 +1245,14 @@ mkSearch :: Maybe Query -> Maybe Filter -> Search
 mkSearch query filter = Search query filter Nothing Nothing Nothing False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing Nothing Nothing
 
 
-
-mkCount :: Maybe Query -> Count
-mkCount query = Count query SearchTypeQueryThenFetch
-  
--- | 'mkCountSearch' is a helper function for defaulting additional fields of a 'Search'
---   to Nothing in case you only care about your 'Query' and 'Filter'. Use record update
---   syntax if you want to add things like aggregations or highlights while still using
---   this helper function.
+-- | 'mkCount' is a helper function for defaulting additional field of a 'Count'
+--   and resemble the similar function for Search endpoint
 --
 -- >>> let query = TermQuery (Term "user" "bitemyapp") Nothing
--- >>> mkCountSearch (Just query) Nothing
--- Search {queryBody = Just (TermQuery (Term {termField = "user", termValue = "bitemyapp"}) Nothing), filterBody = Nothing, searchAfterKey = Nothing, sortBody = Nothing, aggBody = Nothing, highlight = Nothing, trackSortScores = False, from = From 0, size = Size 10, searchType = SearchTypeQueryThenFetch, fields = Nothing, source = Nothing}
-mkCountSearch :: Maybe Query -> Maybe Filter -> Search
-mkCountSearch query filter = Search query filter Nothing Nothing Nothing False (From 0) (Size 10) SearchTypeQueryThenFetch Nothing Nothing Nothing Nothing Nothing
+-- >>> mkCount (Just query)
+-- Count {countQueryBody = Just (TermQuery (Term {termField = "user", termValue = "bitemyapp"}) Nothing), countSearchType = SearchTypeQueryThenFetch}
+mkCount :: Maybe Query -> Count
+mkCount query = Count query SearchTypeQueryThenFetch
 
   
 -- | 'mkAggregateSearch' is a helper function that defaults everything in a 'Search' except for

--- a/src/Database/Bloodhound/Client.hs
+++ b/src/Database/Bloodhound/Client.hs
@@ -57,6 +57,7 @@ module Database.Bloodhound.Client
        -- ** Searching
        , searchAll
        , searchByIndex
+       , countByIndex
        , searchByIndices
        , searchByIndexTemplate
        , searchByIndicesTemplate
@@ -1069,6 +1070,16 @@ searchAll = bindM2 dispatchSearch url . return
 searchByIndex :: MonadBH m => IndexName -> Search -> m Reply
 searchByIndex (IndexName indexName) = bindM2 dispatchSearch url . return
   where url = joinPath [indexName, "_search"]
+
+-- | 'countByIndex', given a 'Search' and an 'IndexName', will perform that search
+--   within an index on an Elasticsearch server.
+--
+-- >>> let query = TermQuery (Term "user" "bitemyapp") Nothing
+-- >>> let search = mkSearch (Just query) Nothing
+-- >>> reply <- runBH' $ countByIndex testIndex search
+countByIndex :: MonadBH m => IndexName -> Search -> m Reply
+countByIndex (IndexName indexName) = bindM2 dispatchSearch url . return
+  where url = joinPath [indexName, "_count"]
 
 -- | 'searchByIndices' is a variant of 'searchByIndex' that executes a
 --   'Search' over many indices. This is much faster than using

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -539,6 +539,18 @@ newtype Pattern = Pattern Text deriving (Eq, Read, Show)
 instance ToJSON Pattern where
   toJSON (Pattern pattern) = toJSON pattern
 
+data CountResult a =
+  CountResult { crCount         :: Int
+               , crShards       :: ShardResult
+               }
+  deriving (Eq, Show)
+
+instance (FromJSON a) => FromJSON (CountResult a) where
+  parseJSON (Object v) = CountResult <$>
+                         v .:  "count"         <*>
+                         v .:  "_shards"
+  parseJSON _          = empty
+  
 data SearchResult a =
   SearchResult { took         :: Int
                , timedOut     :: Bool

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -105,6 +105,7 @@ module Database.Bloodhound.Types
        , JoinRelation(..)
        , IndexDocumentSettings(..)
        , Query(..)
+       , Count(..)
        , Search(..)
        , SearchType(..)
        , SearchResult(..)
@@ -459,7 +460,15 @@ data Search = Search { queryBody       :: Maybe Query
                      , suggestBody     :: Maybe Suggest -- ^ Only one Suggestion request / response per Search is supported.
                      } deriving (Eq, Show)
 
+data Count = Count { countQueryBody       :: Maybe Query
+                    , countSearchType      :: SearchType
+                     } deriving (Eq, Show)
 
+instance ToJSON Count where
+  toJSON (Count mquery _) =
+    omitNulls [ "query" .= mquery]
+
+  
 instance ToJSON Search where
   toJSON (Search mquery sFilter sort searchAggs
           highlight sTrackSortScores sFrom sSize _ sAfter sFields

--- a/src/Database/Bloodhound/Types.hs
+++ b/src/Database/Bloodhound/Types.hs
@@ -109,6 +109,7 @@ module Database.Bloodhound.Types
        , Search(..)
        , SearchType(..)
        , SearchResult(..)
+       , CountResult(..)
        , ScrollId(..)
        , HitsTotalRelation(..)
        , HitsTotal(..)


### PR DESCRIPTION
While working with ES Api, we found that there is a `count` API endpoint that gives a simple way to get the number of hits for a specific query (without scroll, as would be the case if we use search API).

This PR adds a basic support for `count` API endpoint: 
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html

I hope this will be useful.

BR,
Maria